### PR TITLE
Changed my_books to global scope, removed geo query, changed title to be...

### DIFF
--- a/samples/booksSample.html
+++ b/samples/booksSample.html
@@ -9,15 +9,20 @@
         <script src="http://code.jquery.com/mobile/1.1.1/jquery.mobile-1.1.1.min.js"></script>
         <script src="../bin/apigee.min.js"></script>
         <script type="text/javascript">
-        
+
+            //We start by creating an instance of Apigee.Client to carry our App Services credentials        
             var apigee = new Apigee.Client({
                 orgName:'YOUR APIGEE.COM USERNAME',
                 appName:'sandbox'
             });
-
+            
             // If you lock down your sandbox or use any other app
             // a user login is required to access the data.
-            apigee.login("myuser","mypass");
+            //apigee.login("myuser","mypass");
+
+            // We now define my_books within the global scope
+            var my_books = new Apigee.Collection( { "client":apigee, "type":"books" } );
+
 
             $(document).ready(function () {
                 $('#create-button').bind('click', createBook);
@@ -26,9 +31,6 @@
             });
 
             function loadBooks (location) {
-                // We now define my_books within the local scope
-                // so we can pass it our latitude & longitude
-                var my_books = new Apigee.Collection( { "client":apigee, "type":"books", "qs":{"ql":"location within 15000 of "+location.coords.latitude+","+location.coords.longitude} } );
                 
                 my_books.fetch( // Actual network call
 
@@ -54,7 +56,7 @@
 
             function createBook() {
 
-                new_book = { "title":$("#title-field").val(),
+                new_book = { "name":$("#title-field").val(),
                             "author":$("#author-field").val() };
 
                 my_books.addEntity(new_book, function (error, response) {


### PR DESCRIPTION
... saved in 'name' property

Three changes:
- Moved my_books var to global scope. Current version was throwing an error because creatbooks() could not access the my_books Collection object.

-Removed the geolocation query from my_books instantiation. The rest of the app does not use geo, and for new users, they will get an empty result set because of this, which can create confusion.

-The val of 'title-field' is now saved in 'name' property not 'title' property. The createEntity method relies on the SDK fetch() method, which requires all entities to have a 'name' or 'username' property, which is causing the create to fail in this app.
