### PR TITLE
Improved MonitoringClient handling

### DIFF
--- a/samples/mobileAnalyticsSample.html
+++ b/samples/mobileAnalyticsSample.html
@@ -20,34 +20,53 @@
    
   <script src="https://codiqa.com/view/adeb8234/js"></script>
 
-  <script src="../js/apigee.js"></script>
+  <script src="../source/apigee.js"></script>
   <script>
-    var max = new Apigee.MobileAnalytics({
-        orgName:"mdobson",
-        appName:"sandbox",
-        apiUrl:"http://pjha-ug.elasticbeanstalk.com/"
+    var monitoringClient = new Apigee.MonitoringClient({
+   		//Replace 'YOUR_ORG' and 'YOUR_APP' with your Apigee organization and application names
+        orgName:"YOUR_ORG",
+        appName:"YOUR_APP",
+        //URI:"http://apigee-internal-prod.jupiter.apigee.net" //uncomment and change if logging to somewhere other than default Apigee server
     });
-    max.startSession();
+    monitoringClient.startSession();
   </script>
   <script>
-    $(document).ready(function(){
-      $("#req").on("click", function(e){
-        var url = "https://api.usergrid.com/"+$("#org").val()+'/'+$("#app").val();
-        $.get(url, function(data){ alert(data)});
-      });
+  
+	    $(document).ready(function(){	      
+	      $("#org").val(monitoringClient.orgName);
+	      $("#app").val(monitoringClient.appName);
 
-      $("#log").on("click", function(e){
-        max.logDebug({tag:"CLICKS", logMessage:$("#message").val()});
-      });
+	      $("#org, #app").on("change",function(){
+			monitoringClient.orgName = $("#org").val();
+			monitoringClient.appName = $("#app").val();			
+			monitoringClient.downloadConfig();
+			monitoringClient.startSession();
+	      });
 
-      $("#crash").on("click", function(e){
-        foo();
-      });
-    });
+	      $("#req").on("click", function(e){
+	        var url = monitoringClient.URI+"/"+$("#org").val()+'/'+$("#app").val();
+	        var jqxhr = $.get(url, function(data){
+				//alert('successfully reached ' + url);
+			})
+			.fail(function() { alert("error. unable to reach " + url); });
+	      });
+
+	      $("#log").on("click", function(e){
+			var messageToLog = $("#message").val();
+	        monitoringClient.logDebug({tag:"CLICKS", logMessage:messageToLog});
+			console.log(messageToLog + ' (via console)');
+	      });
+
+	      $("#crash").on("click", function(e){
+	        foo();
+	      });
+	    });
+
   </script>
 </head>
 <body>
-  <!-- Home -->
+
+</script>  <!-- Home -->
   <div data-role="page" id="page1">
       <div data-theme="e" data-role="header">
           <h3>
@@ -59,13 +78,13 @@
               <label for="textinput1">
                   orgName
               </label>
-              <input name="" placeholder="" value="mdobson" type="text" id="org">
+              <input name="" placeholder="" value="Your org name" id="org">
           </div>
           <div data-role="fieldcontain">
               <label for="textinput2">
                   appName
               </label>
-              <input name="" placeholder="" value="sandbox" type="text" id="app">
+              <input name="" placeholder="" value="Your app name" type="text" id="app">
           </div>
           <a data-role="button" href="#page1" id="req">
               Make a request


### PR DESCRIPTION
Five changes:

-Added code comments to initial instantiation of Apigee.MonitoringClient

-Changed apiUrl in MonitoringClient instantiation to URI. apiUrl was used in a previous version of the SDK, but has since been changed to URI.

-Pre-populate orgName and appName fields with the value of orgName and appName vars

-Changed url var (line 47) to use monitoringClient.URI instead of static URL

-Auto-update MonitoringClient whenever value of appName or orgName field changes. This includes:

-Setting monitoringClient.orgName and monitoringClient.appName

-Re-download apigeeMobileConfig with downloadConfig() so that 'Log a Message' feature works properly

-Re-start session with startSession() so that session data is captured for the right org/app.
